### PR TITLE
Updaded dependencies and use exact version numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
   "name": "sweetify",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Browserify transform to use Sweet.js macros",
   "main": "index.js",
   "dependencies": {
-    "browser-resolve": "~1.2.2",
-    "sweet.js": "~0.4.1",
-    "through": "~2.3.4",
+    "browser-resolve": "1.3.2",
+    "sweet.js": "0.7.1",
+    "through": "2.3.4",
     "map-async": "~0.1.1",
-    "convert-source-map": "~0.3.3"
+    "convert-source-map": "0.4.1"
   },
   "devDependencies": {
-    "browserify": "~3.23.1",
-    "semver": "~2.2.1",
-    "mocha": "~1.17.0",
-    "jshint": "~2.4.2",
-    "esprima": "~1.0.4"
+    "browserify": "5.10.1",
+    "semver": "3.0.1",
+    "mocha": "1.21.4",
+    "jshint": "2.5.5",
+    "esprima": "1.2.2"
   },
   "scripts": {
     "test": "mocha -R spec specs/*.js"


### PR DESCRIPTION
I updated the dependencies because the current version of sweetify won't work with a lot of macros like es6-macros.
