### PR TITLE
allow loading macros globally

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,9 +75,11 @@ function resolveAndLoadModules(ids, opts, cb) {
   });
 }
 
-module.exports = function(filename) {
+module.exports = function(filename, opts) {
   if (!isSJS.exec(filename))
     return through();
+    
+  opts = opts || {};
 
   var buffer = '';
 
@@ -91,6 +93,15 @@ module.exports = function(filename) {
         includes = extractMacroIncludes(buffer);
       } catch(e) {
         return stream.emit('error', e);
+      }
+
+      // load macros for all files
+      if (opts.modules && opts.modules.length) {
+        opts.modules.forEach(function(moduleName){
+          if (includes.indexOf(moduleName) === -1) {
+            includes.push(moduleName);
+          }
+        });
       }
 
       resolveAndLoadModules(includes, {filename: filename}, function(err, modules) {


### PR DESCRIPTION
I understand the reasoning for declaring macros in every file (explicitness), but if I have 3 macros/packages from npm, and I want to use them in many files, it's a lot of cruft that I want to eliminate.  Especially when it's just converting future syntax to current.

This lets you declare what macros to include when browserifying, and still allows the `import macros from` to work.

The usage in package.json:

``` js
"browserify": {
  "transform": [
    ["sweetify", {"modules": ["es6-macros", "sweet-es7-promise"]}]
  ]
}
```

JS API:

``` js
.transform('sweetify', {modules: ['es6-macros', 'sweet-es7-promise']})
```
