### PR TITLE
Makes sweetJS extension configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,10 +74,10 @@ function resolveAndLoadModules(ids, opts, cb) {
 }
 
 module.exports = function(filename, opts) {
-  if (!module.exports.extensions.exec(filename))
-    return through();
-
   opts = opts || {};
+  opts.extensions = opts.extensions || /.+\.sjs$/;
+  if (!opts.extensions.exec(filename))
+    return through();
 
   var buffer = '';
 
@@ -129,5 +129,3 @@ module.exports = function(filename, opts) {
       });
     });
 }
-
-module.exports.extensions = /.+\.sjs$/;

--- a/index.js
+++ b/index.js
@@ -111,12 +111,16 @@ module.exports = function(filename, opts) {
 
         modules.unshift(eliminateIncludeMacros);
 
+        var sweetOpts = {};
+        for(var k in opts) {
+          sweetOpts[k] = opts[k];
+        }
+        sweetOpts.modules = modules;
+        sweetOpts.sourceMap = true;
+        sweetOpts.filename = filename;
+
         try {
-          r = sweet.compile(buffer, {
-            modules: modules,
-            sourceMap: true,
-            filename: filename
-          });
+          r = sweet.compile(buffer, sweetOpts);
         } catch(e) {
           return stream.emit('error', e);
         }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ var through   = require('through');
 var sweet     = require('sweet.js');
 var resolve   = require('browser-resolve');
 
-var isSJS = /.+\.sjs$/;
-
 var eliminateIncludeMacros = sweet.loadNodeModule(
       process.cwd(),
       require.resolve('./import-macros.sjs'));
@@ -76,9 +74,9 @@ function resolveAndLoadModules(ids, opts, cb) {
 }
 
 module.exports = function(filename, opts) {
-  if (!isSJS.exec(filename))
+  if (!module.exports.extensions.exec(filename))
     return through();
-    
+
   opts = opts || {};
 
   var buffer = '';
@@ -131,3 +129,5 @@ module.exports = function(filename, opts) {
       });
     });
 }
+
+module.exports.extensions = /.+\.sjs$/;


### PR DESCRIPTION
It'd be nice to be able to configure the extension(s) considered when parsing SweetJS files. At my current company we name macro files using `*.sjs` and parsed files using `*.js`. I'm not sure if this is how you'd like to expose the option, but I figured a PR was more actionable than an issue.

Cheers,
Josh
