### PR TITLE
Feature/pass sweetjs opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,10 +74,10 @@ function resolveAndLoadModules(ids, opts, cb) {
 }
 
 module.exports = function(filename, opts) {
-  if (!module.exports.extensions.exec(filename))
-    return through();
-
   opts = opts || {};
+  opts.extensions = opts.extensions || /.+\.sjs$/;
+  if (!opts.extensions.exec(filename))
+    return through();
 
   var buffer = '';
 
@@ -129,5 +129,3 @@ module.exports = function(filename, opts) {
       });
     });
 }
-
-module.exports.extensions = /.+\.sjs$/;

--- a/index.js
+++ b/index.js
@@ -111,12 +111,16 @@ module.exports = function(filename, opts) {
 
         modules.unshift(eliminateIncludeMacros);
 
+        var sweetOpts = {};
+        for(var k in opts) {
+          sweetOpts[k] = opts[k];
+        }
+        sweetOpts.modules = modules;
+        sweetOpts.sourceMap = true;
+        sweetOpts.filename = filename;
+
         try {
-          r = sweet.compile(buffer, {
-            modules: modules,
-            sourceMap: true,
-            filename: filename
-          });
+          r = sweet.compile(buffer, sweetOpts);
         } catch(e) {
           return stream.emit('error', e);
         }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ var through   = require('through');
 var sweet     = require('sweet.js');
 var resolve   = require('browser-resolve');
 
-var isSJS = /.+\.sjs$/;
-
 var eliminateIncludeMacros = sweet.loadNodeModule(
       process.cwd(),
       require.resolve('./import-macros.sjs'));
@@ -76,9 +74,9 @@ function resolveAndLoadModules(ids, opts, cb) {
 }
 
 module.exports = function(filename, opts) {
-  if (!isSJS.exec(filename))
+  if (!module.exports.extensions.exec(filename))
     return through();
-    
+
   opts = opts || {};
 
   var buffer = '';
@@ -131,3 +129,5 @@ module.exports = function(filename, opts) {
       });
     });
 }
+
+module.exports.extensions = /.+\.sjs$/;


### PR DESCRIPTION
I found myself wanting to enable readableNames, and thought a more general use mechanism was in order. I've intentionally avoided sanitizing the opts so that the codebase doesn't need updated when new feature flags are added in sweet.js. Arguably it might be worthwhile to strip sweetify opts out before passing to sweet.js, though I haven't found any realistic cases where this would be a problem.
